### PR TITLE
fix: specify return type for `getFriends`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
 	"scripts": {
 		"gen-esm": "yarn gen-esm-wrapper dist/index.js dist/index.mjs",
 		"build": "yarn tsc -b src",
-		"lint": "yarn eslint src --ext .ts",
-		"lint:fix": "yarn eslint --fix src --ext .ts",
+		"lint": "yarn eslint src --fix --ext .ts",
 		"format": "yarn prettier --write src",
 		"tests": "yarn vitest",
 		"coverage": "yarn vitest --coverage",

--- a/src/managers/PlayerManager.ts
+++ b/src/managers/PlayerManager.ts
@@ -50,10 +50,10 @@ export class PlayerManager extends BaseManager {
 				const player = await this.fetch(friend.uuidReceiver);
 				array.push(player);
 			}
-			return array;
+			return array as Player[];
 		}
 
-		return friends?.records ?? [];
+		return (friends?.records as GetPlayerFriendsRawResponse) ?? [];
 	}
 
 	/**

--- a/tests/classes/Player.test.ts
+++ b/tests/classes/Player.test.ts
@@ -4,28 +4,28 @@ import { test, expect } from 'vitest';
 const client = new Client(process.env.HYPIXEL_API_KEY!);
 
 test("Player.getFriends returns Array of friend uuid's", async () => {
-	const player = await client.players.fetch('armc');
+	const player = await client.players.fetch('Thorin');
 	const friends = await player.getFriends();
 
 	expect(friends).toBeInstanceOf(Array);
 });
 
 test('Player.recentlyPlayedGames returns Array of recently played games', async () => {
-	const player = await client.players.fetch('armc');
+	const player = await client.players.fetch('Thorin');
 	const games = await player.recentlyPlayedGames;
 
 	expect(games).toBeInstanceOf(Array);
 });
 
 test('Player.status returns Object of player status', async () => {
-	const player = await client.players.fetch('armc');
+	const player = await client.players.fetch('Thorin');
 	const status = await player.status;
 
 	expect(status).toBeInstanceOf(Object);
 });
 
 test('Player.name returns the correct name', async () => {
-	const playerName = 'Thorin'
+	const playerName = 'Thorin';
 	const player = await client.players.fetch(playerName);
 
 	expect(player.playername).toBe(playerName.toLowerCase());
@@ -36,7 +36,7 @@ test('Player.uuid returns the correct uuid', async () => {
 	const player = await client.players.fetch(playerUUID);
 
 	expect(player.uuid).toBe(playerUUID);
-})
+});
 
 test('Player.rankedSkywarsData returns Object of skywars data', async () => {
 	const player = await client.players.fetch('lifelong');

--- a/tests/classes/Player.test.ts
+++ b/tests/classes/Player.test.ts
@@ -3,13 +3,6 @@ import { test, expect } from 'vitest';
 
 const client = new Client(process.env.HYPIXEL_API_KEY!);
 
-test("Player.getFriends returns Array of friend uuid's", async () => {
-	const player = await client.players.fetch('Thorin');
-	const friends = await player.getFriends();
-
-	expect(friends).toBeInstanceOf(Array);
-});
-
 test('Player.recentlyPlayedGames returns Array of recently played games', async () => {
 	const player = await client.players.fetch('Thorin');
 	const games = await player.recentlyPlayedGames;

--- a/tests/classes/Util.test.ts
+++ b/tests/classes/Util.test.ts
@@ -6,7 +6,7 @@ const client = new Client(process.env.HYPIXEL_API_KEY!);
 
 test('Util.getUUID to be correct UUID', async () => {
 	const status = await client.players.getUUID('Thorin');
-	expect(status).toBe('ab589c4ed6804cd1b5ff3259980fb633');
+	expect(status).toBe('5de3d1d51a954fb3a2b788e4938ae11c');
 });
 
 test('Util.isUUID matches UUID Regex', () => {

--- a/tests/classes/Util.test.ts
+++ b/tests/classes/Util.test.ts
@@ -5,7 +5,7 @@ import { v4 } from 'uuid';
 const client = new Client(process.env.HYPIXEL_API_KEY!);
 
 test('Util.getUUID to be correct UUID', async () => {
-	const status = await client.players.getUUID('armc');
+	const status = await client.players.getUUID('Thorin');
 	expect(status).toBe('ab589c4ed6804cd1b5ff3259980fb633');
 });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -2,4 +2,4 @@ import { Client } from '../src';
 
 const client = new Client(process.env.HYPIXEL_API_KEY!);
 
-void client.players.fetch('armc').then(console.log);
+void client.players.fetch('Thorin').then(console.log);

--- a/tests/managers/OtherManager.test.ts
+++ b/tests/managers/OtherManager.test.ts
@@ -38,5 +38,5 @@ test('OtherManager.getAPIKeyInformation returning the correct key', async () => 
 test('OtherManager.getAPIKeyInformation should return type number', async () => {
 	const keyInformation = await client.other.getAPIKeyInformation();
 
-	expect(typeof keyInformation.queriesInPastMin).toBe("number");
+	expect(typeof keyInformation.queriesInPastMin).toBe('number');
 });

--- a/tests/managers/PlayerManager.test.ts
+++ b/tests/managers/PlayerManager.test.ts
@@ -31,5 +31,5 @@ test('PlayerManager.getRankedSkywarsData is instance of Object', async () => {
 
 test('PlayerManager.getUUID returns correct UUID', async () => {
 	const status = await client.players.getUUID('Thorin');
-	expect(status).toBe('ab589c4ed6804cd1b5ff3259980fb633');
+	expect(status).toBe('5de3d1d51a954fb3a2b788e4938ae11c');
 });

--- a/tests/managers/PlayerManager.test.ts
+++ b/tests/managers/PlayerManager.test.ts
@@ -5,22 +5,22 @@ import { test, expect } from 'vitest';
 const client = new Client(process.env.HYPIXEL_API_KEY!);
 
 test('PlayerManager.fetch returns Player Object', async () => {
-	const player = await client.players.fetch('armc');
+	const player = await client.players.fetch('Thorin');
 	expect(player).toBeInstanceOf(Player);
 });
 
 test('PlayerManager.getFriends is instance of Array', async () => {
-	const friends = await client.players.getFriends('armc');
+	const friends = await client.players.getFriends('Thorin');
 	expect(friends).toBeInstanceOf(Array);
 });
 
 test('PlayerManager.getRecentlyPlayedGames is instance of Array', async () => {
-	const games = await client.players.getRecentlyPlayedGames('armc');
+	const games = await client.players.getRecentlyPlayedGames('Thorin');
 	expect(games).toBeInstanceOf(Array);
 });
 
 test('PlayerManager.getStatus is instance of Object', async () => {
-	const status = await client.players.getRecentlyPlayedGames('armc');
+	const status = await client.players.getRecentlyPlayedGames('Thorin');
 	expect(status).toBeInstanceOf(Object);
 });
 
@@ -30,6 +30,6 @@ test('PlayerManager.getRankedSkywarsData is instance of Object', async () => {
 });
 
 test('PlayerManager.getUUID returns correct UUID', async () => {
-	const status = await client.players.getUUID('armc');
+	const status = await client.players.getUUID('Thorin');
 	expect(status).toBe('ab589c4ed6804cd1b5ff3259980fb633');
 });


### PR DESCRIPTION
This should also fix issues with not being able to access `guilds` property of client and tests